### PR TITLE
Fix batch request_memory and dependency name bugs

### DIFF
--- a/tests/worker/aws_batch_test.py
+++ b/tests/worker/aws_batch_test.py
@@ -66,10 +66,22 @@ def create_state(NewState):
         'worker': worker,
         'bundle_service': mock.create_autospec(BundleServiceClient),
         'bundle_path': '/tmp/fake_uuid',  # TODO Probably have a random path joined with test name
-        'resources': {'docker_image': 'fake image'},
+        'resources': {'docker_image': 'fake image', 'request_memory': BATCH_DEFAULT_MEMORY},
         'dependencies': {}
     }
     return NewState(**kwargs)
+
+
+class AwsBatchRunTest(unittest.TestCase):
+    def test_requires_memory(self):
+        def create(resources):
+            AwsBatchRun(bundle_service=None, batch_client=None, queue_name=None, worker=None, bundle={'uuid': 'foo'},
+                        bundle_path=None, resources=resources)
+
+        with self.assertRaises(AssertionError):
+            create(resources={})
+
+        create({'request_memory': BATCH_DEFAULT_MEMORY})
 
 
 class InitialStateTest(unittest.TestCase):

--- a/tests/worker/aws_batch_test.py
+++ b/tests/worker/aws_batch_test.py
@@ -160,7 +160,13 @@ class SetupStateTest(unittest.TestCase):
             ['/tmp/fsdfd', '/fsdfd', 'fsdfd'],
             # Contains illegal characters
             ['/tmp/foo.bar.*', '/foo.bar.*', 'foo.bar.*'],
-            ['/tmp/%s' % long_name, '/%s' % long_name, long_name]
+            # Long name
+            ['/tmp/%s' % long_name, '/%s' % long_name, long_name],
+            # Duplicate names after cleaning
+            ['/tmp/a', '/a', 'a!'],
+            ['/tmp/ab', '/ab', 'a@'],
+            ['/tmp/ac', '/ac', 'a#'],
+            ['/tmp/ad', '/ad', 'a.'],
         ]
         job_definition = setup.get_job_definition()
         check_volume_sanity(job_definition)

--- a/worker/codalabworker/aws_batch.py
+++ b/worker/codalabworker/aws_batch.py
@@ -21,7 +21,7 @@ def current_time():
 BYTES_PER_MEGABYTE = 1024 * 1024
 
 # AWS Batch always requires the amount of memory to be specified. We provide a reasonable default here.
-BATCH_DEFAULT_MEMORY = 100 * BYTES_PER_MEGABYTE
+BATCH_DEFAULT_MEMORY = 1024 * BYTES_PER_MEGABYTE
 
 
 class AwsBatchRunManager(RunManagerBase):

--- a/worker/codalabworker/aws_batch.py
+++ b/worker/codalabworker/aws_batch.py
@@ -2,6 +2,7 @@ import logging
 import os
 import socket
 import time
+import re
 
 import fsm
 from bundle_service_client import BundleServiceException
@@ -368,11 +369,14 @@ class Setup(AwsBatchRunState):
             name=self.uuid,
             read_only=False
         )]
-        for host_path, docker_path, uuid in dependencies:
+        for host_path, docker_path, name in dependencies:
+            # Batch has some restrictions with the name, so force it to conform
+            # See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#volumes
+            clean_name = re.sub(r'[^a-zA-Z0-9_-]', '', name)[:244]
             volumes_and_mounts.append(self.volume_and_mount(
                 host_path=host_path,
                 container_path=docker_path,
-                name='dependency_'+uuid,
+                name='dependency_'+clean_name,
                 read_only=True
             ))
 

--- a/worker/codalabworker/docker_run.py
+++ b/worker/codalabworker/docker_run.py
@@ -488,11 +488,3 @@ class Run(FilesystemRunMixin, RunBase):
     def _set_finished(self):
         with self._finished_lock:
             self._finished = True
-
-    @property
-    def requested_memory_bytes(self):
-        """
-        If request_memory is defined, then return that.
-        Otherwise, this run's memory usage does not get checked, so return inf.
-        """
-        return self._resources['request_memory'] or float('inf')

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -155,6 +155,8 @@ class Worker(object):
 
     def _run(self, bundle, resources):
         if self.shared_file_system:
+            assert 'location' in bundle, \
+                "Bundle location not provided by master with shared file system. Are you running as the master user?"
             bundle_path = bundle['location']
         else:
             bundle_path = self._dependency_manager.get_run_path(bundle['uuid'])


### PR DESCRIPTION
Fixes the following bugs:

1) Submitting a job to a batch worker without setting `--request-memory` consumes all memory for that worker so no other jobs can be submitted until it is complete
2) Submitting a job with a dependency name which certain characters causes job submission to fail because batch rejects the volume name in the job definition registration.

I also did two drives bys to add a better error message when an expectation fails and to remove some duplicate code.

This has been tested against the batch queue `codalab-test` to verify the changes work as expected. Once these are merged I will update our docker deployed image.