### PR TITLE
add extra headers from config to rest api calls

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -139,8 +139,9 @@ class JsonApiClient(RestClient):
     """
     Simple JSON API client.
     """
-    def __init__(self, address, get_access_token, check_version=lambda _: None):
+    def __init__(self, address, get_access_token, extra_headers={}, check_version=lambda _: None):
         self._get_access_token = get_access_token
+        self._extra_headers = extra_headers
         self._check_version = check_version
         self.address = address  # Used as key in client and token caches
         base_url = address + '/rest'

--- a/codalab/rest/cli.py
+++ b/codalab/rest/cli.py
@@ -104,7 +104,8 @@ def create_cli(worksheet_uuid):
     requests directly to the appropriate Bottle view functions.
     """
     output_buffer = StringIO()
-    rest_client = JsonApiClient(rest_url(), get_user_token)
+    rest_extra_headers = local.config['server'].get('extra_headers', {})
+    rest_client = JsonApiClient(rest_url(), get_user_token, rest_extra_headers)
     manager = CodaLabManager(
         temporary=True,
         config=local.config,

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -18,12 +18,13 @@ class RestOAuthHandler(object):
     Handles user authentication with the REST bundle service server. Fetches
     other user records from the local database.
     """
-    def __init__(self, address):
+    def __init__(self, address, extra_headers={}):
         """
         address: the address of the server
         model: BundleModel instance
         """
         self._address = address
+        self._extra_headers = extra_headers
 
     def generate_token(self, grant_type, username, key):
         """
@@ -52,6 +53,7 @@ class RestOAuthHandler(object):
             'Content-Type': 'application/x-www-form-urlencoded',
             'Authorization': 'Basic ' + base64.b64encode('codalab_cli_client:'),
             'X-Requested-With': 'XMLHttpRequest'}
+        headers.update(self._extra_headers)
         request = urllib2.Request(
             self._address + '/rest/oauth2/token',
             headers=headers,

--- a/tests/client/json_api_client_test.py
+++ b/tests/client/json_api_client_test.py
@@ -13,7 +13,7 @@ from codalab.common import PreconditionViolation
 
 class JsonApiClientTest(unittest.TestCase):
     def setUp(self):
-        self.client = JsonApiClient('', lambda: None)
+        self.client = JsonApiClient('', {}, lambda: None)
 
     def test_pack_params(self):
         self.assertItemsEqual(self.client._pack_params({

--- a/worker/codalabworker/rest_client.py
+++ b/worker/codalabworker/rest_client.py
@@ -26,6 +26,11 @@ class RestClient(object):
     Generic class for communicating with a REST API authenticated by OAuth.
     """
 
+    """
+    A dictionary of additional headers to send along with HTTP requests.
+    """
+    _extra_headers = {}
+
     def __init__(self, base_url):
         self._base_url = base_url
 
@@ -58,6 +63,8 @@ class RestClient(object):
         if data and isinstance(data, unicode):
             data = data.encode('utf-8')
         request_url = (self._base_url + path).encode('utf-8')
+
+        headers.update(self._extra_headers)
 
         request = urllib2.Request(request_url, data=data, headers=headers)
         request.get_method = lambda: method
@@ -99,9 +106,14 @@ class RestClient(object):
             conn.putrequest(method, parsed_base_url.path + path)
 
             # Set headers.
-            conn.putheader('Authorization', 'Bearer ' + self._get_access_token())
-            conn.putheader('Transfer-Encoding', 'chunked')
-            conn.putheader('X-Requested-With', 'XMLHttpRequest')
+            headers = {
+                'Authorization': 'Bearer ' + self._get_access_token(),
+                'Transfer-Encoding': 'chunked',
+                'X-Requested-With': 'XMLHttpRequest',
+            }
+            headers.update(self._extra_headers)
+            for header_name, header_value in headers.iteritems():
+                conn.putheader(header_name, header_value)
             conn.endheaders()
 
             # Use chunked transfer encoding to send the data through.


### PR DESCRIPTION
Adds support for writing additional headers in the config file to send along with API requests.