### PR TITLE
Uploading archives from Windows bugfix

### DIFF
--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -152,7 +152,7 @@ def pack_files_for_upload(sources, should_unpack, follow_symlinks,
             }
         elif path_is_archive(source):
             return {
-                'fileobj': open(source),
+                'fileobj': open(source, mode='rb'),
                 'filename': filename,
                 'filesize': os.path.getsize(source),
                 'should_unpack': should_unpack,
@@ -168,7 +168,7 @@ def pack_files_for_upload(sources, should_unpack, follow_symlinks,
             }
         else:
             return {
-                'fileobj': open(source),
+                'fileobj': open(source, mode='rb'),
                 'filename': filename,
                 'filesize': os.path.getsize(source),
                 'should_unpack': False,


### PR DESCRIPTION

**Problem:** Couldn't upload `app-library.zip` to my worksheet on codalab from Windows command prompt. @jder was able to reproduce this on his Windows machine (in powershell) but was able to successfully upload the same archive file from Mac. 

**Example**: Upload fails pretty soon but a bundle id is returned
```
>cl upload -w 0x80634ab085db4c8ba9560b01a6907846 -p app-library.zip
Preparing upload archive...
Uploading app-library.zip (0x5b1d277eadb54ea58e71fea117f7aa3c) to https://codalab.semanticmachines.com
Sent 0.06MiB / 852.52MiB (0.0%) [0.11MiB/sec]
0x5b1d277eadb54ea58e71fea117f7aa3c
```

Paired with @jder to resolve this issue. The solution is to open files in binary mode. The `read()` method silently fails possibly due to Windows encountering what it thinks is an undefined character. This doesn't surface in Python2.7 but when we attempted to `open()` and `read()` the same `app-library.zip` in Python3.6 the `read()` method failed with the following error message:
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 75: character maps to <undefined>`