### PR TITLE
render the fields of tables from search directives

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -524,6 +524,8 @@ def get_default_schemas():
 
     return schemas
 
+def get_command(value_obj):  # For directives only
+    return value_obj[0] if len(value_obj) > 0 else None
 
 def interpret_items(schemas, raw_items):
     """


### PR DESCRIPTION
Suppose we have:

```% schema run
% add stdout /stdout
% display table run
% search type=run
```

Before: table cells would render as `(<uuid>,/stdout)`.

After: table cells render as the actual resolved contents.

See the results here on this instance (for now):
http://pliang-1.internal.sm:8000/worksheets/0xa11530dbf5354141ad6f7b7096d87f4f/

Now we can have a nice worksheet that shows, say the 10 most recent runs according to some filter with all the usual stats, without worrying about worksheets getting too long / rotating them...