### PR TITLE
Fix syntax error in setup.py exposed by newer versions of PiP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ doc
 codalab/tests
 codalab/tags
 notes.otl
+
+# Distribution / packaging
+.Python
+env/

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -21,7 +21,7 @@ setup(name='codalabworker',
     license='Apache License 2.0',
     keywords='codalab reproducible computation worksheets competitions worker',
     packages=find_packages(include=['codalabworker*']),
-    package_data={'': 'requirements.txt'},
+    package_data={'': ['requirements.txt']},
     include_package_data=True,
     install_requires=get_requirements('./requirements.txt'),
     entry_points={


### PR DESCRIPTION
When setting up `codalab-cli` with `pip` version 19.3, the following error was encountered:
```
    ERROR: Command errored out with exit status 1:
     command: /Users/rispeyer/src/codalab-cli/env/bin/python2.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/rispeyer/src/codalab-cli/worker/setup.py'"'"'; __file__='"'"'/Users/rispeyer/src/codalab-cli/worker/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /Users/rispeyer/src/codalab-cli/worker/
    Complete output (1 lines):
    error in codalabworker setup command: "values of 'package_data' dict" must be a list of strings (got 'requirements.txt')
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Fix is straightforward to proper syntax